### PR TITLE
feat: @Step, @Attachment, @FileAttachment decorators

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,10 @@ module.exports = {
     "unicorn/consistent-function-scoping": "off",
     "unicorn/filename-case": "off",
     "unicorn/no-array-callback-reference": "off",
+    "unicorn/no-array-method-this-argument": "off",
+    "unicorn/no-array-reduce": "off",
     "unicorn/no-null": "off",
+    "unicorn/no-this-assignment": "off",
     "unicorn/prefer-event-target": "off",
     "unicorn/prefer-module": "off",
     "import/no-extraneous-dependencies": ["error", {
@@ -43,6 +46,7 @@ module.exports = {
       optionalDependencies: false,
     }],
     "@typescript-eslint/consistent-type-imports": "error",
+    "@typescript-eslint/no-this-alias": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/docs/docs/introduction/index.mdx
+++ b/docs/docs/introduction/index.mdx
@@ -32,8 +32,8 @@ It provides several **entry points**:
 <dl>
   <dt><code>jest-allure2-reporter</code></dt>
   <dd>The reporter itself, which is responsible for collecting test results and generating a report.</dd>
-  <dt><code>jest-allure2-reporter</code></dt>
-  <dd>A set of functions and decorators to add additional metadata to your tests.</dd>
+  <dd>DSL to add additional metadata to your test definitions: <code>$Link</code>, <code>$Owner</code>.</dd>
+  <dd>`allure` runtime API to use inside your tests: <code>allure.step</code>, <code>allure.attachment</code>.</dd>
   <dt>
     <b>Environment packages</b>, to enable the annotations, media attachments and provide additional test data:
   </dt>
@@ -43,8 +43,8 @@ It provides several **entry points**:
       <dd>For Node.js tests.</dd>
       <dt><code>jest-allure2-reporter/environment-jsdom</code></dt>
       <dd>For browser tests.</dd>
-      <dt><code>jest-allure2-reporter/environment-extend</code></dt>
-      <dd>For advanced use cases where you need to extend your already customized test environment.</dd>
+      <dt><code>jest-allure2-reporter/environment-decorator</code></dt>
+      <dd>For advanced use cases where you need to extend an already customized test environment.</dd>
     </dl>
   </dd>
 </dl>

--- a/e2e/fixtures/invalid-email.xml
+++ b/e2e/fixtures/invalid-email.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validation result="failed">
+  <error message="Invalid e-mail format" />
+</validation>

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,3 +1,3 @@
-const PRESET = process.env.ALLURE_PRESET ?? 'default';
+const ALLURE_PRESET = process.env.ALLURE_PRESET ?? 'default';
 
-module.exports = require(`./configs/${PRESET}`);
+module.exports = require(`./configs/${ALLURE_PRESET}`);

--- a/e2e/src/programmatic/grouping/client/auth/LoginScreen.test.ts
+++ b/e2e/src/programmatic/grouping/client/auth/LoginScreen.test.ts
@@ -1,4 +1,5 @@
 import { $Epic, $Feature, $Story, $Tag } from 'jest-allure2-reporter';
+import LoginHelper from '../../../../utils/LoginHelper';
 
 $Tag('client');
 $Epic('Authentication');
@@ -13,8 +14,9 @@ describe('Login screen', () => {
 
   $Story('Validation');
   describe('Form Submission', () => {
-    it('should show error on invalid e-mail format', () => {
-      // ...
+    it('should show error on invalid e-mail format', async () => {
+      await LoginHelper.typeEmail('someone#example.com');
+      expect(LoginHelper.getValidationSummary()).toBe('fixtures/invalid-email.xml');
     });
 
     it('should show error on short or invalid password format', () => {

--- a/e2e/src/simple.not-test.ts
+++ b/e2e/src/simple.not-test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {
   allure,
   $Description,
@@ -5,15 +6,16 @@ import {
   $Severity,
   $Link,
 } from 'jest-allure2-reporter';
+import {LoginHelper} from "./utils/LoginHelper";
 
 $Description('Sanity test for Allure reporter');
 $Owner('Yaroslav Serhieiev <yaroslavs@wix.com>');
 describe('Simple suite', () => {
   beforeAll(() => {
     console.log('beforeAll');
-    allure.fileAttachment(
+    allure.createFileAttachment(
       'Project Logo',
-      '/home/x/Projects/wix-incubator/jest-allure2-reporter/docs/img/logo.svg',
+      path.resolve('../docs/img/logo.svg'),
       'image/svg+xml',
     );
   });
@@ -32,12 +34,8 @@ describe('Simple suite', () => {
       });
 
       allure.step('Inner step 2', () => {
-        allure.attachment(
-          'Some code',
-          'console.log("Hello, World!");',
-          'text/plain',
-        );
-        expect(true).toBe(false);
+        const helper = new LoginHelper();
+        expect(helper.typeEmail('allure@wix-incubator.com')).toBe('Entered: allure@wix-incubator.com');
       });
     });
   });

--- a/e2e/src/utils/LoginHelper.ts
+++ b/e2e/src/utils/LoginHelper.ts
@@ -1,0 +1,16 @@
+import {Attachment, FileAttachment, Step} from 'jest-allure2-reporter';
+
+class LoginHelper {
+  @Step('Type e-mail', ['E-mail'])
+  @Attachment('email.txt')
+  async typeEmail(email: string) {
+    return 'Entered: ' + email;
+  }
+
+  @FileAttachment('summary.xml', 'text/xml')
+  getValidationSummary() {
+    return 'fixtures/invalid-email.xml';
+  }
+}
+
+export default new LoginHelper();

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "node16",
     "ignoreDeprecations": "5.0",
+    "experimentalDecorators": true,
     "noEmit": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@noomorph/allure-js-commons": "^2.3.0",
     "ci-info": "^3.8.0",
-    "jest-metadata": "^1.0.2",
+    "jest-metadata": "^1.1.1",
     "pkg-up": "^3.1.0",
     "rimraf": "^4.3.1",
     "strip-ansi": "^6.0.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,10 @@
 export const PREFIX = 'allure2' as const;
 
+export const OUT_DIR = [PREFIX, 'config', 'outDir'] as const;
+
 export const CODE = [PREFIX, 'code'] as const;
 export const WORKER_ID = [PREFIX, 'workerId'] as const;
+export const HIDDEN = [PREFIX, 'hidden'] as const;
 
 export const START = [PREFIX, 'start'] as const;
 

--- a/src/decorators/Attachment.ts
+++ b/src/decorators/Attachment.ts
@@ -1,3 +1,19 @@
-export function Attachment() {
-  // TODO: Implement
+import realm from '../realms';
+
+const allure = realm.runtime;
+
+export function Attachment(filename: string, contentType?: string) {
+  return function (
+    _target: object,
+    _propertyName: string,
+    descriptor: TypedPropertyDescriptor<(...arguments_: any[]) => any>,
+  ) {
+    descriptor.value = allure.createAttachment(
+      filename,
+      descriptor.value!,
+      contentType,
+    );
+
+    return descriptor;
+  };
 }

--- a/src/decorators/FileAttachment.ts
+++ b/src/decorators/FileAttachment.ts
@@ -1,3 +1,19 @@
-export function FileAttachment() {
-  // TODO: Implement
+import realm from '../realms';
+
+const allure = realm.runtime;
+
+export function FileAttachment(fileName: string, contentType: string) {
+  return function (
+    _target: object,
+    _propertyName: string,
+    descriptor: TypedPropertyDescriptor<(...arguments_: any[]) => any>,
+  ) {
+    descriptor.value = allure.createFileAttachment(
+      fileName,
+      descriptor.value!,
+      contentType,
+    );
+
+    return descriptor;
+  };
 }

--- a/src/decorators/Step.ts
+++ b/src/decorators/Step.ts
@@ -1,3 +1,18 @@
-export function Step() {
-  // TODO: Implement
+import realm from '../realms';
+import type { ParameterOrString } from '../utils/types';
+
+const allure = realm.runtime;
+
+export function Step(name: string, arguments_?: ParameterOrString[]) {
+  return function (
+    _target: object,
+    _propertyName: string,
+    descriptor: TypedPropertyDescriptor<(...arguments_: any[]) => Promise<any>>,
+  ) {
+    descriptor.value = arguments_
+      ? allure.createStep(name, arguments_, descriptor.value!)
+      : allure.createStep(name, descriptor.value!);
+
+    return descriptor;
+  };
 }

--- a/src/environment/decorator.ts
+++ b/src/environment/decorator.ts
@@ -49,16 +49,18 @@ export function WithAllure2<E extends WithEmitter>(
         event,
       }: ForwardedCircusEvent<Circus.Event & { name: 'add_hook' }>) {
         const sourceCode = event.fn.toString();
-        if (
-          !sourceCode.includes(
-            "during setup, this cannot be null (and it's fine to explode if it is)",
-          )
-        ) {
-          const metadata = {
-            code: [sourceCode],
-          } as AllureTestStepMetadata;
-          state.currentMetadata.assign(PREFIX, metadata);
+        const hidden = sourceCode.includes(
+          "during setup, this cannot be null (and it's fine to explode if it is)",
+        );
+
+        const metadata = {
+          code: [sourceCode],
+        } as AllureTestStepMetadata;
+        if (hidden) {
+          delete metadata.code;
+          metadata.hidden = true;
         }
+        state.currentMetadata.assign(PREFIX, metadata);
       }
 
       #addTest({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export { JestAllure2Reporter } from './reporter/JestAllure2Reporter';
 export { JestAllure2Reporter as default } from './reporter/JestAllure2Reporter';
 export { ReporterOptions } from './options/ReporterOptions';
 export * from './annotations';
+export * from './decorators';
 
 export const allure = realm.runtime;

--- a/src/metadata/MetadataSquasher.ts
+++ b/src/metadata/MetadataSquasher.ts
@@ -16,10 +16,8 @@ import type { AllureTestCaseMetadata } from './metadata';
 export class MetadataSquasher {
   protected readonly testInvocationConfig: MetadataSquasherConfig<AllureTestCaseMetadata>;
 
-  constructor(flat: boolean) {
-    this.testInvocationConfig = flat
-      ? MetadataSquasher.flatConfig()
-      : MetadataSquasher.deepConfig();
+  constructor() {
+    this.testInvocationConfig = MetadataSquasher.flatConfig();
   }
 
   testInvocation(metadata: TestInvocationMetadata): AllureTestCaseMetadata {
@@ -78,13 +76,13 @@ export class MetadataSquasher {
     };
   }
 
-  private static deepConfig(): MetadataSquasherConfig<AllureTestCaseMetadata> {
-    return {
-      ...this.flatConfig(),
-      attachments: chain(['testEntry', 'testInvocation']),
-      parameters: chain(['testEntry', 'testInvocation']),
-    };
-  }
+  // private static deepConfig(): MetadataSquasherConfig<AllureTestCaseMetadata> {
+  //   return {
+  //     ...this.flatConfig(),
+  //     attachments: chain(['testEntry', 'testInvocation']),
+  //     parameters: chain(['testEntry', 'testInvocation']),
+  //   };
+  // }
 }
 
 export type MetadataSquasherConfig<T extends object> = {

--- a/src/metadata/StepExtractor.ts
+++ b/src/metadata/StepExtractor.ts
@@ -4,22 +4,27 @@ import type {
   TestFnInvocationMetadata,
 } from 'jest-metadata';
 
-import { PREFIX } from '../constants';
+import { HIDDEN, PREFIX } from '../constants';
 
 import type { AllureTestStepMetadata } from './metadata';
 
 export class StepExtractor {
-  constructor(protected readonly flat: boolean) {}
-
   public extractFromInvocation(
     metadata: HookInvocationMetadata<any> | TestFnInvocationMetadata,
-  ): AllureTestStepMetadata {
+  ): AllureTestStepMetadata | null {
+    const definition = metadata.definition as HookDefinitionMetadata;
+    const hidden = metadata.get(HIDDEN, definition.get(HIDDEN, false));
+    if (hidden) {
+      return null;
+    }
+
+    const hookType = definition.hookType;
     const data = {
-      name: (metadata.definition as HookDefinitionMetadata).hookType ?? 'test',
+      name: hookType,
       ...(metadata.get([PREFIX]) as AllureTestStepMetadata),
     };
 
-    if (this.flat) {
+    if (!hookType) {
       delete data.attachments;
       delete data.parameters;
     }

--- a/src/metadata/metadata.ts
+++ b/src/metadata/metadata.ts
@@ -10,6 +10,11 @@ import type {
 
 export interface AllureTestStepMetadata {
   steps?: AllureTestStepMetadata[];
+  hidden?: boolean;
+  /**
+   * Source code of the test case, test step or a hook.
+   */
+  code?: string[];
 
   name?: string;
   status?: Status;
@@ -34,10 +39,6 @@ export interface AllureTestCaseMetadata extends AllureTestStepMetadata {
    * @see {import('@noomorph/allure-js-commons').LabelName.THREAD}
    */
   workerId?: string;
-  /**
-   * Source code of the test case, glued from all hooks and test function itself.
-   */
-  code?: string[];
   /**
    * Only steps can have names.
    */

--- a/src/options/defaultOptions.ts
+++ b/src/options/defaultOptions.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 import type { TestCaseResult } from '@jest/reporters';
-import type { StatusDetails } from '@noomorph/allure-js-commons';
+import type { Attachment, StatusDetails } from '@noomorph/allure-js-commons';
 import { Stage, Status } from '@noomorph/allure-js-commons';
 
 import { stripStatusDetails } from '../metadata/utils';
@@ -38,7 +38,8 @@ export function defaultOptions(): ReporterConfig {
     stage: ({ testCase }) => getTestCaseStage(testCase),
     status: ({ testCase }) => getTestCaseStatus(testCase),
     statusDetails: ({ testCase }) => getTestCaseStatusDetails(testCase),
-    attachments: ({ testCaseMetadata }) => testCaseMetadata.attachments ?? [],
+    attachments: ({ config, testCaseMetadata }) =>
+      (testCaseMetadata.attachments ?? []).map(relativizeAttachment, config),
     parameters: ({ testCaseMetadata }) => testCaseMetadata.parameters ?? [],
     labels: aggregateLabelCustomizers({
       package: last,
@@ -139,4 +140,14 @@ function getTestCaseStatusDetails(
         trace: message,
       })
     : undefined;
+}
+
+function relativizeAttachment(
+  this: ReporterConfig,
+  attachment: Attachment,
+): Attachment {
+  return {
+    ...attachment,
+    source: path.relative(this.resultsDir, attachment.source),
+  };
 }

--- a/src/runtime/AllureRuntime.test.ts
+++ b/src/runtime/AllureRuntime.test.ts
@@ -11,14 +11,23 @@ describe('AllureRuntime', () => {
     const runtime = new AllureRuntime({
       metadataProvider: () => state,
       nowProvider: () => now++,
-      writeAttachment: (content) => content.toString(),
+      placeAttachment: (_name, content) => {
+        return `/attachments/${content.toString()}`;
+      },
+      writeAttachment: async () => {
+        /* noop */
+      },
     });
 
-    runtime.attachment('attachment1', Buffer.from('first'), 'text/plain');
+    await runtime.createAttachment(
+      'attachment1',
+      Buffer.from('first'),
+      'text/plain',
+    );
     await runtime.step('outer step', async () => {
       try {
         runtime.step('inner step 1', () => {
-          runtime.attachment('attachment2', 'second', 'text/plain');
+          runtime.createAttachment('attachment2', 'second', 'text/plain');
 
           const error = new Error('Sync error');
           error.stack = 'Test stack';
@@ -30,10 +39,10 @@ describe('AllureRuntime', () => {
       runtime.step('inner step 2', () => {
         /* empty */
       });
-      runtime.attachment('attachment3', 'third', 'text/plain');
+      await runtime.createAttachment('attachment3', 'third', 'text/plain');
       await runtime
         .step('inner step 3', async () => {
-          runtime.attachment('attachment4', 'fourth', 'text/plain');
+          await runtime.createAttachment('attachment4', 'fourth', 'text/plain');
 
           const error = new Error('Async error');
           error.stack = 'Test stack';
@@ -43,7 +52,11 @@ describe('AllureRuntime', () => {
           /* empty */
         });
     });
-    runtime.attachment('attachment5', Buffer.from('fifth'), 'text/plain');
+    await runtime.createAttachment(
+      'attachment5',
+      Buffer.from('fifth'),
+      'text/plain',
+    );
     expect(state.get(PREFIX)).toMatchSnapshot();
   });
 });

--- a/src/runtime/__snapshots__/AllureRuntime.test.ts.snap
+++ b/src/runtime/__snapshots__/AllureRuntime.test.ts.snap
@@ -5,12 +5,12 @@ exports[`AllureRuntime should add attachments within the steps 1`] = `
   "attachments": [
     {
       "name": "attachment1",
-      "source": "first",
+      "source": "/attachments/first",
       "type": "text/plain",
     },
     {
       "name": "attachment5",
-      "source": "fifth",
+      "source": "/attachments/fifth",
       "type": "text/plain",
     },
   ],
@@ -20,14 +20,14 @@ exports[`AllureRuntime should add attachments within the steps 1`] = `
       "attachments": [
         {
           "name": "attachment3",
-          "source": "third",
+          "source": "/attachments/third",
           "type": "text/plain",
         },
       ],
       "code": "async () => {
             try {
                 runtime.step('inner step 1', () => {
-                    runtime.attachment('attachment2', 'second', 'text/plain');
+                    runtime.createAttachment('attachment2', 'second', 'text/plain');
                     const error = new Error('Sync error');
                     error.stack = 'Test stack';
                     throw error;
@@ -39,10 +39,10 @@ exports[`AllureRuntime should add attachments within the steps 1`] = `
             runtime.step('inner step 2', () => {
                 /* empty */
             });
-            runtime.attachment('attachment3', 'third', 'text/plain');
+            await runtime.createAttachment('attachment3', 'third', 'text/plain');
             await runtime
                 .step('inner step 3', async () => {
-                runtime.attachment('attachment4', 'fourth', 'text/plain');
+                await runtime.createAttachment('attachment4', 'fourth', 'text/plain');
                 const error = new Error('Async error');
                 error.stack = 'Test stack';
                 throw error;
@@ -61,12 +61,12 @@ exports[`AllureRuntime should add attachments within the steps 1`] = `
           "attachments": [
             {
               "name": "attachment2",
-              "source": "second",
+              "source": "/attachments/second",
               "type": "text/plain",
             },
           ],
           "code": "() => {
-                    runtime.attachment('attachment2', 'second', 'text/plain');
+                    runtime.createAttachment('attachment2', 'second', 'text/plain');
                     const error = new Error('Sync error');
                     error.stack = 'Test stack';
                     throw error;
@@ -96,12 +96,12 @@ exports[`AllureRuntime should add attachments within the steps 1`] = `
           "attachments": [
             {
               "name": "attachment4",
-              "source": "fourth",
+              "source": "/attachments/fourth",
               "type": "text/plain",
             },
           ],
           "code": "async () => {
-                runtime.attachment('attachment4', 'fourth', 'text/plain');
+                await runtime.createAttachment('attachment4', 'fourth', 'text/plain');
                 const error = new Error('Async error');
                 error.stack = 'Test stack';
                 throw error;

--- a/src/utils/hijackValue.test.ts
+++ b/src/utils/hijackValue.test.ts
@@ -1,0 +1,78 @@
+import { hijackValue } from './hijackValue';
+
+describe('hijackValue', () => {
+  // Test: Direct Value
+  it('should call the callback with a direct value', () => {
+    const callback = jest.fn();
+    const result = hijackValue(5, callback);
+
+    expect(callback).toHaveBeenCalledWith(5);
+    expect(result).toBe(5);
+  });
+
+  // Test: Promise
+  it('should call the callback with a resolved promise', async () => {
+    const callback = jest.fn();
+    const promise = Promise.resolve(10);
+    const result = hijackValue(promise, callback);
+
+    await expect(result).resolves.toBe(10);
+    expect(callback).toHaveBeenCalledWith(10);
+  });
+
+  // Test: Synchronous Function
+  it('should call the callback with the value returned from a synchronous function', () => {
+    const callback = jest.fn();
+    const function_ = () => 15;
+    const wrapper = hijackValue(function_, callback);
+
+    expect(wrapper()).toBe(15);
+    expect(callback).toHaveBeenCalledWith(15);
+  });
+
+  // Test: Asynchronous Function
+  it('should call the callback with the value resolved from an asynchronous function', async () => {
+    const callback = jest.fn();
+    const asyncFunction = async () => 20;
+    const wrapper = hijackValue(asyncFunction, callback);
+
+    await expect(wrapper()).resolves.toBe(20);
+    expect(callback).toHaveBeenCalledWith(20);
+  });
+
+  // Test: Ensuring `this` and arguments are preserved in function hijack
+  it('should preserve `this` context and arguments in hijacked function', () => {
+    const function_ = function (
+      this: { multiplier: number },
+      a: number,
+      b: number,
+    ) {
+      return (a + b) * this.multiplier;
+    };
+    const wrapper = hijackValue(function_, (x) => x).bind({ multiplier: 3 });
+
+    expect(wrapper(10, 20)).toBe(90); // (10 + 20) * 3
+  });
+
+  // Test: Proper handling of rejected promises
+  it('should propagate rejection in promises', async () => {
+    const callback = jest.fn();
+    const promise = Promise.reject('Error Message');
+    const result = hijackValue(promise, callback);
+
+    await expect(result).rejects.toBe('Error Message');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  // Test: Function toString() Overriding
+  it('should preserve the toString representation of the original function', () => {
+    const callback = jest.fn();
+    const function_ = function add(a: number, b: number) {
+      return a + b;
+    };
+    const originalToString = function_.toString();
+    const wrapper = hijackValue(function_, callback);
+
+    expect(wrapper.toString()).toBe(originalToString);
+  });
+});

--- a/src/utils/hijackValue.ts
+++ b/src/utils/hijackValue.ts
@@ -1,0 +1,53 @@
+import type { Function_, MaybePromise } from './types';
+import { isPromiseLike } from './isPromiseLike';
+
+export function hijackValue<T>(input: T, callback: (resolvedValue: T) => T): T;
+export function hijackValue<T>(
+  input: Promise<T>,
+  callback: (resolvedValue: T) => T,
+): Promise<T>;
+export function hijackValue<T>(
+  input: Function_<T>,
+  callback: (resolvedValue: T) => T,
+): Function_<T>;
+export function hijackValue<T>(
+  input: Function_<MaybePromise<T>>,
+  callback: (resolvedValue: T) => T,
+): Function_<MaybePromise<T>>;
+export function hijackValue<T>(
+  input: Function_<Promise<T>>,
+  callback: (resolvedValue: T) => T,
+): Function_<Promise<T>>;
+export function hijackValue<T>(
+  input: T | Promise<T> | Function_<MaybePromise<T>>,
+  callback: (resolvedValue: T) => void,
+): typeof input;
+export function hijackValue<T>(
+  input: T | Promise<T> | Function_<MaybePromise<T>>,
+  callback: (resolvedValue: T) => void,
+): typeof input {
+  if (typeof input === 'function') {
+    const function_ = input;
+    const wrapper = function (this: unknown, ...arguments_: any[]) {
+      const result = Reflect.apply(
+        function_,
+        this,
+        arguments_,
+      ) as MaybePromise<T>;
+
+      return isPromiseLike(result)
+        ? result.then(
+            (resolvedValue) => (callback(resolvedValue), resolvedValue),
+          )
+        : (callback(result), result);
+    };
+    wrapper.toString = function_.toString.bind(function_);
+    return wrapper as Function_<T>;
+  } else if (isPromiseLike(input)) {
+    return input.then(
+      (resolvedValue) => (callback(resolvedValue), resolvedValue),
+    );
+  } else {
+    return callback(input), input;
+  }
+}

--- a/src/utils/inferMimeType.ts
+++ b/src/utils/inferMimeType.ts
@@ -1,0 +1,35 @@
+/**
+ * Infers the mime type of a file based on its extension.
+ * @param filePath Path to the file.
+ * @returns The mime type of the file or `application/octet-stream` if the mime type could not be inferred.
+ */
+export function inferMimeType(filePath: string): string {
+  const extension = filePath.split('.').pop()!;
+  return mimeTypes[extension] || 'application/octet-stream';
+}
+
+const mimeTypes: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  ogg: 'video/ogg',
+
+  json: 'application/json',
+  pdf: 'application/pdf',
+  zip: 'application/zip',
+  tar: 'application/x-tar',
+  gz: 'application/gzip',
+  js: 'application/javascript',
+
+  css: 'text/css',
+  html: 'text/html',
+  txt: 'text/plain',
+  csv: 'text/csv',
+  xml: 'text/xml',
+};

--- a/src/utils/isPromiseLike.ts
+++ b/src/utils/isPromiseLike.ts
@@ -1,7 +1,7 @@
-export function isPromiseLike(
-  maybePromise: unknown,
-): maybePromise is PromiseLike<unknown> {
+export function isPromiseLike<T>(
+  maybePromise: T | Promise<T>,
+): maybePromise is Promise<T> {
   return maybePromise
-    ? typeof (maybePromise as PromiseLike<unknown>).then === 'function'
+    ? typeof (maybePromise as PromiseLike<T>).then === 'function'
     : false;
 }

--- a/src/utils/shallowEqualArrays.ts
+++ b/src/utils/shallowEqualArrays.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-null */
-
 type Maybe<T> = T | null | undefined;
 
 export default function shallowEqualArrays(
@@ -18,7 +16,6 @@ export default function shallowEqualArrays(
     return false;
   }
 
-  // eslint-disable-next-line unicorn/no-array-callback-reference,unicorn/no-array-method-this-argument
   return a.every(isItemEqual, b);
 }
 

--- a/src/utils/squash.ts
+++ b/src/utils/squash.ts
@@ -1,5 +1,0 @@
-import type { TestEntryMetadata } from 'jest-metadata';
-
-export function squash(test: TestEntryMetadata): unknown[] {
-  return [test];
-}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,9 @@
+import type { Parameter } from '@noomorph/allure-js-commons';
+
+export type MaybePromise<T> = T | Promise<T>;
+
+export type Function_<T> = (...arguments_: any[]) => T;
+
+export type ParameterOrString = string | Parameter;
+
+export type AttachmentContent = Buffer | string;

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -26,7 +26,7 @@
   --ifm-color-primary-light: #29d5b0;
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
-  --ifm-background-color: #19211d !important;
+  --ifm-background-color: #1c1c1c !important;
   --docusaurus-highlighted-code-line-bg: rgba(255, 0, 255, 0.1);
 }
 


### PR DESCRIPTION
So, now you can do this kind of magic:

```js
import {Attachment, FileAttachment, Step} from 'jest-allure2-reporter';

class LoginHelper {
  @Step('Type e-mail', ['E-mail'])
  @Attachment('email.txt')
  async typeEmail(email: string) {
    return 'Entered: ' + email;
  }

  @FileAttachment('summary.xml', 'text/xml')
  getValidationSummary() {
    return 'fixtures/invalid-email.xml';
  }
}
```

![image](https://github.com/wix-incubator/jest-allure2-reporter/assets/1962469/e8d5963a-a224-4844-a27b-f848105a7e8f)

