### PR TITLE
fix: test duration in fallback mode

### DIFF
--- a/e2e/src/programmatic/grouping/statuses.test.ts
+++ b/e2e/src/programmatic/grouping/statuses.test.ts
@@ -26,6 +26,7 @@ describe('Status tests', () => {
   ])('Status override in a %s', (_parentSuite, callback) => {
     describe.each([
       ['test', (callback: Fn) => (test('', callback), void 0)],
+      ['test step', (callback: Fn) => (test('', () => allure.step('a step', callback)), void 0)],
       ['beforeAll hook', (callback: Fn) => (beforeAll(callback), test('', dummyTest), void 0)],
       ['beforeEach hook', (callback: Fn) => (beforeEach(callback), test('', dummyTest), void 0)],
       ['afterEach hook', (callback: Fn) => (afterEach(callback), test('', dummyTest), void 0)],

--- a/src/metadata/MetadataSquasher.ts
+++ b/src/metadata/MetadataSquasher.ts
@@ -42,12 +42,11 @@ export class MetadataSquasher {
       resolveTestStep,
     );
     const steps = result.steps ?? [];
-    const stage = getStage(metadata);
 
     return {
       ...result,
       ...getStatusAndDetails(metadata),
-      stage,
+      stage: getStage(metadata),
       start: getStart(metadata),
       stop: getStop(metadata),
       steps: [...befores, ...steps, ...afters],

--- a/src/metadata/utils/getStart.ts
+++ b/src/metadata/utils/getStart.ts
@@ -14,6 +14,6 @@ export const getStart = (testInvocation: TestInvocationMetadata) => {
   if (typeof start1 === 'number') {
     return typeof start2 === 'number' ? Math.min(start1, start2) : start1;
   } else {
-    return typeof start2 === 'number' ? start2 : Number.NaN;
+    return typeof start2 === 'number' ? start2 : undefined;
   }
 };

--- a/src/metadata/utils/getStop.ts
+++ b/src/metadata/utils/getStop.ts
@@ -15,6 +15,6 @@ export const getStop = (testInvocation: TestInvocationMetadata) => {
   if (typeof stop1 === 'number') {
     return typeof stop2 === 'number' ? Math.max(stop1, stop2) : stop1;
   } else {
-    return typeof stop2 === 'number' ? stop2 : Number.NaN;
+    return typeof stop2 === 'number' ? stop2 : undefined;
   }
 };

--- a/src/options/default-options/testCase.ts
+++ b/src/options/default-options/testCase.ts
@@ -69,9 +69,7 @@ export const testCase: ResolvedTestCaseCustomizer = {
   statusDetails: ({ testCase, testCaseMetadata }) =>
     stripStatusDetails(
       testCaseMetadata.statusDetails ??
-        stripStatusDetails(
-          getStatusDetails((testCase.failureMessages ?? []).join('\n')),
-        ),
+        getStatusDetails((testCase.failureMessages ?? []).join('\n')),
     ),
   attachments: ({ testCaseMetadata }) => testCaseMetadata.attachments ?? [],
   parameters: ({ testCaseMetadata }) => testCaseMetadata.parameters ?? [],


### PR DESCRIPTION
Due to the incorrect use of `Number.NaN`, our `start` and `stop` selectors did not work correctly.

This pull request fixes broken test durations in Allure reports generated without a custom test environment.