### PR TITLE
fix: parameters serialization

### DIFF
--- a/src/reporter/allure-adapter/normalizeParameters.ts
+++ b/src/reporter/allure-adapter/normalizeParameters.ts
@@ -1,9 +1,13 @@
 import type { AllureTestCaseResult, AllureTestStepResult, Parameter } from 'jest-allure2-reporter';
 
 export function normalizeParameters(result: AllureTestCaseResult | AllureTestStepResult) {
-  return result.parameters?.map(stringifyParameter);
+  return result.parameters?.filter(excludeParameters).map(stringifyParameter);
 }
 
-function stringifyParameter({ name, value }: Parameter) {
-  return { name, value: String(value) };
+function excludeParameters({ excluded }: Parameter) {
+  return !excluded;
+}
+
+function stringifyParameter(parameter: Parameter) {
+  return { ...parameter, value: String(parameter.value) };
 }

--- a/src/runtime/AllureRuntimeImplementation.ts
+++ b/src/runtime/AllureRuntimeImplementation.ts
@@ -100,11 +100,10 @@ export class AllureRuntimeImplementation implements AllureRuntime {
 
   parameter: AllureRuntime['parameter'] = (name, value, options) => {
     typeAssertions.assertString(name, 'name');
-    typeAssertions.assertPrimitive(value, 'value');
 
     this.#coreModule.parameter({
       name,
-      value: String(value),
+      value: typeof value === 'string' ? value : util.inspect(value),
       ...options,
     });
   };

--- a/src/runtime/__snapshots__/runtime.test.ts.snap
+++ b/src/runtime/__snapshots__/runtime.test.ts.snap
@@ -68,6 +68,10 @@ exports[`AllureRuntime should add attachments within the steps 1`] = `
               "name": "0",
               "value": "fourth",
             },
+            {
+              "name": "1",
+              "value": "{ key: 'value' }",
+            },
           ],
           "stage": "interrupted",
           "start": 5,

--- a/src/runtime/runtime.test.ts
+++ b/src/runtime/runtime.test.ts
@@ -43,13 +43,16 @@ describe('AllureRuntime', () => {
 
     expect(resultingPath).toBe('/attachments/first');
 
-    const innerStep3 = runtime.createStep('inner step 3 ({{0}})', async (message: string) => {
-      runtime.attachment('attachment4', message, 'text/plain');
+    const innerStep3 = runtime.createStep(
+      'inner step 3 ({{0}})',
+      async (message: string, _extra: object) => {
+        runtime.attachment('attachment4', message, 'text/plain');
 
-      const error = new Error('Async error');
-      error.stack = 'Error: Async error\n    at innerStep3';
-      throw error;
-    });
+        const error = new Error('Async error');
+        error.stack = 'Error: Async error\n    at innerStep3';
+        throw error;
+      },
+    );
 
     await runtime.step('outer step', async () => {
       try {
@@ -68,7 +71,7 @@ describe('AllureRuntime', () => {
         /* empty */
       });
       runtime.attachment('attachment3', 'third', 'text/plain');
-      await innerStep3('fourth').catch(() => {
+      await innerStep3('fourth', { key: 'value' }).catch(() => {
         /* empty */
       });
     });

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -44,7 +44,7 @@ export interface AllureRuntime {
 
   parameter(name: string, value: unknown, options?: ParameterOptions): void;
 
-  parameters(parameters: Record<string, unknown>): void;
+  parameters(parameters: object): void;
 
   status(status: Status, statusDetails?: StatusDetails): void;
 


### PR DESCRIPTION
* Loosen typing of `allure.parameters`
* Handle non-primitive values using `util.inspect` for stringification
* Fix serialization of `excluded`, `masked` and `hidden` parameters