### PR TITLE
fix: add sourcemap support for setup files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -616,6 +616,7 @@ declare module 'jest-allure2-reporter' {
   /** @inheritDoc */
   export interface AllureTestRunMetadata extends AllureTestCaseMetadata {
     config: unknown;
+    loadedFiles: string[];
     sourceLocation?: never;
     transformedCode?: never;
   }

--- a/src/utils/FileNavigatorCache.ts
+++ b/src/utils/FileNavigatorCache.ts
@@ -8,6 +8,7 @@ import { FileNavigator } from './index';
 
 export class FileNavigatorCache {
   #cache = new Map<string, Promise<FileNavigator | undefined>>();
+  #scannedSourcemaps = new Set<string>();
 
   resolve(filePath: string): Promise<FileNavigator | undefined> {
     const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
@@ -20,6 +21,9 @@ export class FileNavigatorCache {
 
   async scanSourcemap(filePath: string): Promise<void> {
     const sourceMapPath = `${filePath}.map`;
+
+    if (this.#scannedSourcemaps.has(sourceMapPath)) return;
+    this.#scannedSourcemaps.add(sourceMapPath);
 
     const doesNotExist = await fs.access(sourceMapPath).catch(() => true);
     if (doesNotExist) return;


### PR DESCRIPTION
Fixes issue not spotted previously in #49.

Test environment reports extra loaded files, so that reporter can read more sourcemaps.