### PR TITLE
fix: Jest 30 support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+legacy-peer-deps=true

--- a/e2e/demo/navigation/menu.test.ts
+++ b/e2e/demo/navigation/menu.test.ts
@@ -1,10 +1,10 @@
-import { beforeAll, describe, expect, test } from '@jest/globals';
-
 /**
  * ### Navigation test suite
  *
  * This suite tests the navigation elements of the website, focusing on the mobile experience.
  */
+
+import { beforeAll, describe, expect, test } from '@jest/globals';
 import { FakeBrowser, MenuDriver } from '../drivers';
 
 describe('Navigation', () => {

--- a/e2e/demo/navigation/menu.test.ts
+++ b/e2e/demo/navigation/menu.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, test } from '@jest/globals';
+
 /**
  * ### Navigation test suite
  *

--- a/e2e/demo/product-catalog/product-details.test.ts
+++ b/e2e/demo/product-catalog/product-details.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
+
 /**
  * @epic Product Discovery
  * @feature View Product Details
@@ -5,7 +7,6 @@
  * @package com.example.shop.catalog
  * @testClass ProductDetailsController
  */
-
 import { FakeBrowser, ProductDetailsDriver } from '../drivers';
 
 describe('Product Catalog', () => {

--- a/e2e/demo/product-catalog/product-details.test.ts
+++ b/e2e/demo/product-catalog/product-details.test.ts
@@ -1,5 +1,3 @@
-import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
-
 /**
  * @epic Product Discovery
  * @feature View Product Details
@@ -7,6 +5,8 @@ import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
  * @package com.example.shop.catalog
  * @testClass ProductDetailsController
  */
+
+import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
 import { FakeBrowser, ProductDetailsDriver } from '../drivers';
 
 describe('Product Catalog', () => {

--- a/e2e/demo/product-catalog/product-listing.test.ts
+++ b/e2e/demo/product-catalog/product-listing.test.ts
@@ -1,11 +1,11 @@
-import { beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
-
 /**
  * @epic Product Discovery
  * @feature Browse Products
  * @severity blocker
  * @package com.example.shop.catalog
  */
+
+import { beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import { FakeBrowser, ProductListingDriver } from '../drivers';
 
 describe('Product Catalog', () => {

--- a/e2e/demo/product-catalog/product-listing.test.ts
+++ b/e2e/demo/product-catalog/product-listing.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+
 /**
  * @epic Product Discovery
  * @feature Browse Products

--- a/e2e/demo/product-catalog/product-reviews.test.ts
+++ b/e2e/demo/product-catalog/product-reviews.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, test } from '@jest/globals';
+
 /**
  * @epic Product Discovery
  * @feature Read Reviews

--- a/e2e/demo/product-catalog/product-reviews.test.ts
+++ b/e2e/demo/product-catalog/product-reviews.test.ts
@@ -1,10 +1,10 @@
-import { beforeAll, describe, expect, test } from '@jest/globals';
-
 /**
  * @epic Product Discovery
  * @feature Read Reviews
  * @package com.example.shop.reviews
  */
+
+import { beforeAll, describe, expect, test } from '@jest/globals';
 import { FakeBrowser, ProductReviewsDriver } from '../drivers';
 
 describe('Product Catalog', () => {

--- a/e2e/src/LoginHelper.ts
+++ b/e2e/src/LoginHelper.ts
@@ -1,4 +1,4 @@
-import { Step, Attachment, FileAttachment } from '../../dist/api';
+import { Step, Attachment, FileAttachment } from 'jest-allure2-reporter/api';
 
 class LoginHelper {
   #email?: string;

--- a/e2e/tests/regression/edge-cases/history.test.ts
+++ b/e2e/tests/regression/edge-cases/history.test.ts
@@ -1,4 +1,6 @@
-import { allure } from '../../../../dist/api';
+import { describe, it } from '@jest/globals';
+
+import { allure } from 'jest-allure2-reporter/api';
 
 describe('History', () => {
   it.each([

--- a/e2e/tests/regression/edge-cases/names.test.ts
+++ b/e2e/tests/regression/edge-cases/names.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeAll, describe, test } from '@jest/globals';
  * @tag fullName
  * @tag description
  */
-import { $Description, $DisplayName, $FullName, $Link, allure } from "jest-allure2-reporter/api";
+import { $Description, $DisplayName, $FullName, $Link, allure } from 'jest-allure2-reporter/api';
 
 describe('Names', () => {
   // Regular beforeAll

--- a/e2e/tests/regression/edge-cases/names.test.ts
+++ b/e2e/tests/regression/edge-cases/names.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeAll, describe, test } from '@jest/globals';
+
 /**
  * This suite checks how default and custom naming works for test files, test cases and test steps.
  *
@@ -7,7 +9,7 @@
  * @tag fullName
  * @tag description
  */
-import { allure, $Description, $DisplayName, $FullName, $Link } from '../../../../dist/api';
+import { $Description, $DisplayName, $FullName, $Link, allure } from "jest-allure2-reporter/api";
 
 describe('Names', () => {
   // Regular beforeAll

--- a/e2e/tests/regression/edge-cases/statuses.test.ts
+++ b/e2e/tests/regression/edge-cases/statuses.test.ts
@@ -1,4 +1,6 @@
-import { allure } from '../../../../dist/api';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+
+import { allure } from 'jest-allure2-reporter/api';
 
 const dummyTest = () => expect(true).toBe(true);
 const timeoutTest = (_done: Fn) => {

--- a/package-e2e/api.test.ts
+++ b/package-e2e/api.test.ts
@@ -1,20 +1,4 @@
-import {
-  Attachment,
-  FileAttachment,
-  Step,
-  $Description,
-  $DescriptionHtml,
-  $Epic,
-  $Feature,
-  $Issue,
-  $Link,
-  $Owner,
-  $Severity,
-  $Story,
-  $Tag,
-  $TmsLink,
-  allure,
-} from 'jest-allure2-reporter/api';
+import { test } from '@jest/globals';
 
 import type {
   AllureRuntime,
@@ -29,8 +13,25 @@ import type {
   FileAttachmentOptions,
   MIMEInferer,
   MIMEInfererContext,
-  UserParameter,
-} from 'jest-allure2-reporter/api';
+  UserParameter
+} from "jest-allure2-reporter/api";
+import {
+  $Description,
+  $DescriptionHtml,
+  $Epic,
+  $Feature,
+  $Issue,
+  $Link,
+  $Owner,
+  $Severity,
+  $Story,
+  $Tag,
+  $TmsLink,
+  allure,
+  Attachment,
+  FileAttachment,
+  Step
+} from "jest-allure2-reporter/api";
 
 enablePlugins();
 

--- a/package-e2e/api.test.ts
+++ b/package-e2e/api.test.ts
@@ -1,20 +1,3 @@
-import { test } from '@jest/globals';
-
-import type {
-  AllureRuntime,
-  AllureRuntimePluginCallback,
-  AllureRuntimePluginContext,
-  AttachmentContent,
-  ContentAttachmentContext,
-  ContentAttachmentHandler,
-  ContentAttachmentOptions,
-  FileAttachmentContext,
-  FileAttachmentHandler,
-  FileAttachmentOptions,
-  MIMEInferer,
-  MIMEInfererContext,
-  UserParameter
-} from "jest-allure2-reporter/api";
 import {
   $Description,
   $DescriptionHtml,
@@ -31,7 +14,22 @@ import {
   Attachment,
   FileAttachment,
   Step
-} from "jest-allure2-reporter/api";
+} from 'jest-allure2-reporter/api';
+import type {
+  AllureRuntime,
+  AllureRuntimePluginCallback,
+  AllureRuntimePluginContext,
+  AttachmentContent,
+  ContentAttachmentContext,
+  ContentAttachmentHandler,
+  ContentAttachmentOptions,
+  FileAttachmentContext,
+  FileAttachmentHandler,
+  FileAttachmentOptions,
+  MIMEInferer,
+  MIMEInfererContext,
+  UserParameter
+} from 'jest-allure2-reporter/api';
 
 enablePlugins();
 

--- a/package-e2e/globals.test.ts
+++ b/package-e2e/globals.test.ts
@@ -1,4 +1,4 @@
-import 'jest-allure2-reporter/globals';
+import "jest-allure2-reporter/globals";
 
 // Pseudo-annotations
 assertEqualType($Description, global.$Description);

--- a/package-e2e/globals.test.ts
+++ b/package-e2e/globals.test.ts
@@ -1,4 +1,4 @@
-import "jest-allure2-reporter/globals";
+import 'jest-allure2-reporter/globals';
 
 // Pseudo-annotations
 assertEqualType($Description, global.$Description);

--- a/package-e2e/isolation.test.ts
+++ b/package-e2e/isolation.test.ts
@@ -1,5 +1,5 @@
-import 'jest-allure2-reporter';
-import 'jest-allure2-reporter/api';
+import "jest-allure2-reporter";
+import "jest-allure2-reporter/api";
 
 // @ts-expect-error TS2304: Cannot find name '$Description'.
 $Description;

--- a/package-e2e/isolation.test.ts
+++ b/package-e2e/isolation.test.ts
@@ -1,5 +1,5 @@
-import "jest-allure2-reporter";
-import "jest-allure2-reporter/api";
+import 'jest-allure2-reporter';
+import 'jest-allure2-reporter/api';
 
 // @ts-expect-error TS2304: Cannot find name '$Description'.
 $Description;

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
+    "@jest/globals": "^30.0.0",
     "@types/fs-extra": "^11.0.0",
-    "@types/jest": "^29.0.0",
     "@types/lodash": "^4.14.186",
     "@types/node": "^16.0.0",
     "@types/node-fetch": "^2.6.9",
@@ -87,6 +87,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "cz-conventional-changelog": "^3.3.0",
+    "expect": "^30.0.0",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ecmascript-compat": "^3.0.0",
@@ -98,9 +99,10 @@
     "eslint-plugin-unicorn": "^47.0.0",
     "fs-extra": "^10.1.0",
     "husky": "^8.0.1",
-    "jest": "^29.0.0",
-    "jest-environment-jsdom": "^29.0.0",
+    "jest": "^30.0.0",
+    "jest-environment-jsdom": "^30.0.0",
     "lint-staged": "^14.0.1",
+    "prettier": "^3.0.0",
     "semantic-release": "^22.0.5",
     "ts-jest": "^29.0.0",
     "typescript": "5.x.x"
@@ -111,7 +113,7 @@
     "properties": "^1.2.1",
     "handlebars": "^4.7.8",
     "import-from": "^4.0.0",
-    "jest-metadata": "^1.5.5",
+    "jest-metadata": "^1.6.0",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "pkg-up": "^3.1.0",
@@ -133,5 +135,8 @@
   },
   "browserslist": [
     "node 16"
-  ]
+  ],
+  "overrides": {
+    "unrs-resolver": "1.7.13"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -135,8 +135,5 @@
   },
   "browserslist": [
     "node 16"
-  ],
-  "overrides": {
-    "unrs-resolver": "1.7.13"
-  }
+  ]
 }

--- a/src/metadata/squasher/__tests__/mergeTestCaseMetadata.test.ts
+++ b/src/metadata/squasher/__tests__/mergeTestCaseMetadata.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from '@jest/globals';
 import type { AllureTestCaseMetadata, AllureTestStepMetadata } from 'jest-allure2-reporter';
 
 import { MetadataSelector } from '../MetadataSelector';

--- a/src/metadata/squasher/__tests__/mergeTestFileMetadata.test.ts
+++ b/src/metadata/squasher/__tests__/mergeTestFileMetadata.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, test } from '@jest/globals';
 import type { AllureTestFileMetadata, AllureTestStepMetadata } from 'jest-allure2-reporter';
 
 import { MetadataSelector } from '../MetadataSelector';

--- a/src/options/common/appenderExtractor.test.ts
+++ b/src/options/common/appenderExtractor.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { appenderExtractor } from './appenderExtractor';
 
 describe('extractors', () => {
@@ -13,7 +15,7 @@ describe('extractors', () => {
     });
 
     it('should allow the extractor to replace the context value (sync)', async () => {
-      const extractor = jest.fn().mockReturnValue([3, 4]);
+      const extractor = jest.fn<any>().mockReturnValue([3, 4]);
       const context = { value: [1, 2] };
 
       const result = appenderExtractor(extractor)!;
@@ -24,7 +26,7 @@ describe('extractors', () => {
     });
 
     it('should allow the extractor to replace the context value (async)', async () => {
-      const extractor = jest.fn().mockResolvedValue([3, 4]);
+      const extractor = jest.fn<any>().mockResolvedValue([3, 4]);
       const context = { value: Promise.resolve([1, 2]) };
 
       const result = appenderExtractor(extractor)!;
@@ -35,7 +37,7 @@ describe('extractors', () => {
     });
 
     it('should turn undefined results from the extractor into empty arrays', async () => {
-      const extractor = jest.fn().mockReturnValue(void 0);
+      const extractor = jest.fn<any>().mockReturnValue(void 0);
       const context = { value: [1, 2] };
 
       const result = appenderExtractor(extractor)!;

--- a/src/options/common/composeExtractors2.test.ts
+++ b/src/options/common/composeExtractors2.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import type { PropertyExtractor } from 'jest-allure2-reporter';
 
 import { composeExtractors2 } from './composeExtractors2';

--- a/src/options/common/composeExtractors3.test.ts
+++ b/src/options/common/composeExtractors3.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import type { MaybePromise, PropertyExtractor } from 'jest-allure2-reporter';
 
 import { composeExtractors3 } from './composeExtractors3';

--- a/src/options/common/compositeExtractor.test.ts
+++ b/src/options/common/compositeExtractor.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import type { PromisedProperties, PropertyExtractorContext } from 'jest-allure2-reporter';
 
 import { thruMaybePromise } from '../../utils';

--- a/src/options/common/constantExtractor.test.ts
+++ b/src/options/common/constantExtractor.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { constantExtractor } from './constantExtractor';
 
 describe('extractors', () => {
@@ -9,7 +11,7 @@ describe('extractors', () => {
     };
 
     it('should return the extractor function when the input is an extractor', () => {
-      const extractor = jest.fn().mockReturnValue(42);
+      const extractor = jest.fn<any>().mockReturnValue(42);
       const result = constantExtractor(extractor);
 
       expect(result).toBe(extractor);

--- a/src/options/common/last.test.ts
+++ b/src/options/common/last.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { last } from './last';
 
 describe('extractors', () => {

--- a/src/options/common/mergerExtractor.test.ts
+++ b/src/options/common/mergerExtractor.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import type { MaybePromise, PropertyExtractorContext } from 'jest-allure2-reporter';
 
 import { mergerExtractor } from './mergerExtractor';
@@ -18,7 +19,7 @@ describe('extractors', () => {
     });
 
     it('should replace context value with the extracted value (sync)', async () => {
-      const extractor = jest.fn().mockReturnValue({ c: 3, d: 4 });
+      const extractor = jest.fn<any>().mockReturnValue({ c: 3, d: 4 });
       const context = { value: { a: 1, b: 2 } };
 
       const result = mergerExtractor<TestContext, TestValue>(extractor)!;
@@ -29,7 +30,7 @@ describe('extractors', () => {
     });
 
     it('should replace context value with the extracted value (async)', async () => {
-      const extractor = jest.fn().mockResolvedValue({ c: 3, d: 4 });
+      const extractor = jest.fn<any>().mockResolvedValue({ c: 3, d: 4 });
       const context = { value: Promise.resolve({ a: 1, b: 2 }) };
 
       const result = mergerExtractor<TestContext, TestValue>(extractor)!;

--- a/src/options/custom/labels/labels.test.ts
+++ b/src/options/custom/labels/labels.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import type { LabelsCustomizer } from 'jest-allure2-reporter';
 
 import { labels } from './labels';

--- a/src/options/custom/links/links.test.ts
+++ b/src/options/custom/links/links.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import type { LinksCustomizer } from 'jest-allure2-reporter';
 
 import { asArray } from '../../../utils';

--- a/src/options/custom/parameters/parameters.test.ts
+++ b/src/options/custom/parameters/parameters.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import type { ParametersCustomizer } from 'jest-allure2-reporter';
 
 import { parameters } from './parameters';

--- a/src/options/custom/testCase.test.ts
+++ b/src/options/custom/testCase.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals';
 import type { AllureTestCaseResult } from 'jest-allure2-reporter';
 
 import { testCase as testCaseCustomizer } from './testCase';
@@ -23,16 +24,10 @@ describe('testCase', () => {
     ${'descriptionHtml'} | ${''}          | ${'<p>Custom description</p>'}
   `(
     'should extract $property with default value $defaultValue and extracted value $extractedValue',
-    async ({
-      property,
-      defaultValue,
-      extractedValue,
-    }: {
-      property: keyof AllureTestCaseResult;
-      defaultValue: any;
-      extractedValue: any;
-    }) => {
-      const extractor = jest.fn().mockResolvedValue(extractedValue);
+    async (options) => {
+      const { property: _property, defaultValue, extractedValue } = options;
+      const property = _property as keyof AllureTestCaseResult;
+      const extractor = jest.fn<any>().mockResolvedValue(extractedValue);
       const testCase = testCaseCustomizer({ [property]: extractor });
       const result = testCase(createTestCaseContext({ [property]: defaultValue }));
 

--- a/src/options/custom/testCaseSteps.test.ts
+++ b/src/options/custom/testCaseSteps.test.ts
@@ -1,8 +1,9 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import type {
-  PropertyExtractorContext,
-  PromisedProperties,
-  TestCaseExtractorContext,
   AllureTestStepResult,
+  PromisedProperties,
+  PropertyExtractorContext,
+  TestCaseExtractorContext,
 } from 'jest-allure2-reporter';
 
 import { testStep } from './testStep';
@@ -12,7 +13,7 @@ import { createTestCaseContext } from './__utils__/contexts';
 describe('testCaseSteps', () => {
   it('should extract nested steps', async () => {
     let counter = 0;
-    const displayName = jest.fn().mockImplementation(() => `Step ${++counter}`);
+    const displayName = jest.fn<any>().mockImplementation(() => `Step ${++counter}`);
     const testStepExtractor = testStep({ displayName });
     const testCase = testCaseSteps(testStepExtractor, 'testCaseMetadata');
     const context: PropertyExtractorContext<

--- a/src/options/custom/testStep.test.ts
+++ b/src/options/custom/testStep.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals';
 import type {
   AllureTestStepResult,
   PromisedProperties,
@@ -42,16 +43,10 @@ describe('testStepCustomizer', () => {
     ${'parameters'}    | ${[]}          | ${[{ name: 'param1', value: 'value1' }, { name: 'param2', value: 'value2' }]}
   `(
     'should asynchronously customize $property with $customValue yet to be able to access the default value $defaultValue',
-    async ({
-      property,
-      defaultValue,
-      customValue,
-    }: {
-      property: keyof AllureTestStepResult;
-      defaultValue: any;
-      customValue: any;
-    }) => {
-      const asyncExtractor = jest.fn().mockResolvedValue(customValue);
+    async (options) => {
+      const { property: _property, defaultValue, customValue } = options;
+      const property = _property as keyof AllureTestStepResult;
+      const asyncExtractor = jest.fn<any>().mockResolvedValue(customValue);
       const testStep = testStepCustomizer({ [property]: asyncExtractor });
       const context = createContext({ [property]: defaultValue });
       const result = testStep(context) as AllureTestStepResult;
@@ -80,15 +75,9 @@ describe('testStepCustomizer', () => {
     ${'parameters'}    | ${[]}          | ${[{ name: 'param1', value: 'value1' }, { name: 'param2', value: 'value2' }]}
   `(
     'should synchronously customize $property with $customValue yet to be able to access the default value $defaultValue',
-    ({
-      property,
-      defaultValue,
-      customValue,
-    }: {
-      property: keyof AllureTestStepResult;
-      defaultValue: any;
-      customValue: any;
-    }) => {
+    (options) => {
+      const { property: _property, defaultValue, customValue } = options;
+      const property = _property as keyof AllureTestStepResult;
       const syncExtractor = jest.fn().mockReturnValue(customValue);
       const testStep = testStepCustomizer({ [property]: syncExtractor });
       const context = createContext({ [property]: defaultValue });
@@ -109,24 +98,15 @@ describe('testStepCustomizer', () => {
     property      | defaultValue    | customValue
     ${'steps'}    | ${undefined}    | ${[]}
     ${'hookType'} | ${'beforeEach'} | ${'afterEach'}
-  `(
-    'should not be able to customize $property',
-    async ({
-      property,
-      defaultValue,
-      customValue,
-    }: {
-      property: keyof AllureTestStepResult;
-      defaultValue: any;
-      customValue: any;
-    }) => {
-      const extractor = jest.fn().mockResolvedValue(customValue);
-      const testStep = testStepCustomizer({ [property]: extractor });
-      const context = createContext({ [property]: defaultValue });
-      const result = testStep(context) as AllureTestStepResult;
+  `('should not be able to customize $property', async (options) => {
+    const { property: _property, defaultValue, customValue } = options;
+    const property = _property as keyof AllureTestStepResult;
+    const extractor = jest.fn<any>().mockResolvedValue(customValue);
+    const testStep = testStepCustomizer({ [property]: extractor });
+    const context = createContext({ [property]: defaultValue });
+    const result = testStep(context) as AllureTestStepResult;
 
-      expect(result?.[property]).toBe(defaultValue);
-      expect(extractor).not.toHaveBeenCalled();
-    },
-  );
+    expect(result?.[property]).toBe(defaultValue);
+    expect(extractor).not.toHaveBeenCalled();
+  });
 });

--- a/src/options/helpers/manifest/ManifestResolver.test.ts
+++ b/src/options/helpers/manifest/ManifestResolver.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { ManifestResolver } from './ManifestResolver';
 
 describe('manifest', () => {

--- a/src/options/helpers/strip-ansi/stripAnsi.test.ts
+++ b/src/options/helpers/strip-ansi/stripAnsi.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from '@jest/globals';
+
 import { stripAnsi } from './stripAnsi';
 
 describe('stripAnsi', () => {

--- a/src/runtime/runtime.test.ts
+++ b/src/runtime/runtime.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 
+import { describe, expect, it } from '@jest/globals';
 import { state } from 'jest-metadata';
 
 import { AllureMetadataProxy } from '../metadata';

--- a/src/source-code/javascript/extractDocblockAbove.test.ts
+++ b/src/source-code/javascript/extractDocblockAbove.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { FileNavigator } from '../../utils';
 
 import { extractDocblockAbove as extractJsDocument_ } from './extractDocblockAbove';

--- a/src/utils/DeferredTaskQueue.test.ts
+++ b/src/utils/DeferredTaskQueue.test.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
 import type { DeferredTaskQueueConfig } from './DeferredTaskQueue';
 import { DeferredTaskQueue } from './DeferredTaskQueue';
 
@@ -14,14 +16,14 @@ type TaskPayload = {
 
 describe('DeferredTaskQueue', () => {
   let taskQueue: DeferredTaskQueue<TaskPayload, string | number>;
-  let mockExecute: jest.Mock;
-  let getThreadName: jest.Mock;
-  let getPayloadKey: jest.Mock;
+  let mockExecute: ReturnType<typeof jest.fn>;
+  let getThreadName: ReturnType<typeof jest.fn>;
+  let getPayloadKey: ReturnType<typeof jest.fn>;
   let config: DeferredTaskQueueConfig<TaskPayload, string | number>;
 
-  let taskBegin: jest.Mock;
-  let taskEnd: jest.Mock;
-  let taskFailed: jest.Mock;
+  let taskBegin: ReturnType<typeof jest.fn>;
+  let taskEnd: ReturnType<typeof jest.fn>;
+  let taskFailed: ReturnType<typeof jest.fn>;
   const taskPayloads: { [id: string | number]: TaskPayload } = {};
 
   const createPayload = (
@@ -58,11 +60,11 @@ describe('DeferredTaskQueue', () => {
     for (const key in taskPayloads) delete taskPayloads[key];
 
     getThreadName = jest
-      .fn()
+      .fn<any>()
       .mockImplementation((payload: TaskPayload) => payload.thread || 'default');
-    getPayloadKey = jest.fn().mockImplementation((payload: TaskPayload) => payload.id);
+    getPayloadKey = jest.fn<any>().mockImplementation((payload: TaskPayload) => payload.id);
 
-    mockExecute = jest.fn().mockImplementation(async (payload: TaskPayload) => {
+    mockExecute = jest.fn<any>().mockImplementation(async (payload: TaskPayload) => {
       taskBegin(payload.id);
       // Use a promise that resolves/rejects based on setTimeout with fake timers
       return new Promise<void>((resolve, reject) => {

--- a/src/utils/FileNavigator.test.ts
+++ b/src/utils/FileNavigator.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, beforeEach, describe, expect, it, test } from '@jest/globals';
+
 import { FileNavigator } from './FileNavigator';
 
 describe('FileNavigator', () => {
@@ -118,7 +120,9 @@ describe('FileNavigator', () => {
   });
 
   describe('moveUp/moveDown', () => {
-    beforeEach(() => navigator.jump(1));
+    beforeEach(() => {
+      navigator.jump(1);
+    });
 
     it('should move down and up', () => {
       expect(navigator.moveDown()).toBe(true);

--- a/src/utils/FileNavigatorCache.test.ts
+++ b/src/utils/FileNavigatorCache.test.ts
@@ -1,10 +1,12 @@
-jest.mock('../logger');
-
 import path from 'node:path';
+
+import { describe, expect, jest, test } from '@jest/globals';
 
 import { log } from '../logger';
 
 import { FileNavigatorCache } from './FileNavigatorCache';
+
+jest.mock('../logger');
 
 const __FIXTURES__ = path.join(__dirname, '__fixtures__');
 

--- a/src/utils/compactObject.test.ts
+++ b/src/utils/compactObject.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { compactObject } from './compactObject';
 
 describe('compactObject', () => {

--- a/src/utils/fastMove.test.ts
+++ b/src/utils/fastMove.test.ts
@@ -2,6 +2,8 @@ import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
 import { fastMove } from './fastMove';
 
 describe('fastMove', () => {

--- a/src/utils/flatMapAsync.test.ts
+++ b/src/utils/flatMapAsync.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { flatMapAsync } from './flatMapAsync';
 
 describe('flatMapAsync', () => {

--- a/src/utils/getFullExtension.test.ts
+++ b/src/utils/getFullExtension.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { getFullExtension } from './getFullExtension';
 
 describe('getFullExtension', () => {

--- a/src/utils/getStatusDetails.test.ts
+++ b/src/utils/getStatusDetails.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { getStatusDetails } from './getStatusDetails';
 
 describe('getStatusDetails', () => {

--- a/src/utils/hijackFunction.test.ts
+++ b/src/utils/hijackFunction.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { hijackFunction } from './hijackFunction';
 
 describe('hijackFunction', () => {

--- a/src/utils/isJestAssertionError.ts
+++ b/src/utils/isJestAssertionError.ts
@@ -1,3 +1,4 @@
+/* eslint-disable-next-line node/no-unpublished-import */
 import type { JestAssertionError } from 'expect';
 
 import { isObject } from './vendor';

--- a/src/utils/isLibraryPath.test.ts
+++ b/src/utils/isLibraryPath.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { isLibraryPath } from './isLibraryPath';
 
 describe('isLibraryPath', () => {

--- a/src/utils/stringifyValues.test.ts
+++ b/src/utils/stringifyValues.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { stringifyValues } from './stringifyValues';
 
 describe('stringifyValues', () => {

--- a/src/utils/thruMaybePromise.test.ts
+++ b/src/utils/thruMaybePromise.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import { thruMaybePromise } from './thruMaybePromise';
 
 describe('thruMaybePromise', () => {

--- a/src/utils/weakMemoize.test.ts
+++ b/src/utils/weakMemoize.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import { weakMemoize } from './weakMemoize';
 
 describe('weakMemoize', () => {


### PR DESCRIPTION
This PR brings a few adjustments to make sure `jest-allure2-reporter` works with Jest 30.